### PR TITLE
transcoding: job: cleanup and deduplicate data structures

### DIFF
--- a/client/transcoding/job_dto.go
+++ b/client/transcoding/job_dto.go
@@ -1,60 +1,102 @@
 package transcoding
 
-import "time"
+import (
+	"time"
 
-// JobID is our job's unique identifier
-type JobID string
-
-// CreateJobRequest contains the parameters needed to create a new transcode job
-type CreateJobRequest struct {
-	Source              string                      `json:"source"`
-	SourceInfo          CreateJobSourceInfo         `json:"sourceInfo,omitempty"`
-	Name                string                      `json:"name,omitempty"`
-	DestinationBasePath string                      `json:"destinationBasePath,omitempty"`
-	Outputs             []JobOutput                 `json:"outputs"`
-	Provider            string                      `json:"provider"`
-	StreamingParams     StreamingParams             `json:"streamingParams,omitempty"`
-	SidecarAssets       map[SidecarAssetKind]string `json:"sidecarAssets,omitempty"`
-	ExecutionFeatures   ExecutionFeatures           `json:"executionFeatures,omitempty"`
-	ExecutionEnv        ExecutionEnvironment        `json:"executionEnv,omitempty"`
-}
+	"github.com/cbsinteractive/pkg/timecode"
+)
 
 // ScanType is a string that represents the scan type of the content.
 type ScanType string
 
 const (
-	// ScanTypeProgressive represents a progressive scan type
+	ScanTypeUnknown     ScanType = "unknown"
 	ScanTypeProgressive ScanType = "progressive"
-
-	// ScanTypeInterlaced represents a interlaced scan type
-	ScanTypeInterlaced ScanType = "interlaced"
-
-	// ScanTypeUnknown represents an unknown scan type
-	ScanTypeUnknown ScanType = "unknown"
+	ScanTypeInterlaced  ScanType = "interlaced"
 )
 
-// CreateJobSourceInfo represents basic information about the source when creating a job that may be of aid to providers
-type CreateJobSourceInfo struct {
-	Width     uint     `json:"width,omitempty"`
-	Height    uint     `json:"height,omitempty"`
-	FrameRate float64  `json:"frameRate,omitempty"`
-	FileSize  int64    `json:"fileSize,omitempty"`
-	ScanType  ScanType `json:"scanType,omitempty"`
-}
-
 // ComputeClass represents a group of resources with similar capability
+// TODO(as): This is a type alias, we shouldn't be using it.
 type ComputeClass = string
 
 const (
-	// ComputeClassTranscodeDefault runs any default transcodes
-	ComputeClassTranscodeDefault ComputeClass = "transcodeDefault"
-
-	// ComputeClassDolbyVisionTranscode runs Dolby Vision transcodes
-	ComputeClassDolbyVisionTranscode ComputeClass = "doViTranscode"
-
-	// ComputeClassDolbyVisionPreprocess runs Dolby Vision pre-processing
-	ComputeClassDolbyVisionPreprocess ComputeClass = "doViPreprocess"
+	ComputeClassTranscodeDefault      ComputeClass = "transcodeDefault" // any default transcodes
+	ComputeClassDolbyVisionTranscode  ComputeClass = "doViTranscode"    // Dolby Vision transcodes
+	ComputeClassDolbyVisionPreprocess ComputeClass = "doViPreprocess"   // Dolby Vision pre-processing
 )
+
+// SidecarAssetKindDolbyVisionMetadata defines the dolby vision dynamic metadata location
+const SidecarAssetKindDolbyVisionMetadata SidecarAssetKind = "dolbyVisionMetadata"
+
+type (
+	// JobID is our job's unique identifier
+	JobID string
+
+	// Status is the status of a transcoding job.
+	Status string
+
+	// ExecutionFeatures is a map whose key is a custom feature name and value is a json string
+	// representing the corresponding custom feature definition
+	ExecutionFeatures map[string]interface{}
+
+	// SidecarAssetKind is the type of sidecar asset being defined
+	// TODO(as): This is a type alias, we shouldn't be using it.
+	SidecarAssetKind = string
+)
+
+// File is a media file. It replaces the following objects
+// SourceInfo: Duration, Height, Width, Codec
+// CreateJobSourceInfo: Height, Width, FrameRate, File Size, ScanType
+// SourceInfo:
+type File struct {
+	Path       string        `json:"path"`
+	Size       int64         `json:"fileSize"`
+	Container  string        `json:"container"`
+	Duration   time.Duration `json:"duration,omitempty"`
+	VideoCodec string        `json:"videoCodec,omitempty"`
+	Width      int           `json:"width,omitempty"`
+	Height     int           `json:"height,omitempty"`
+	FrameRate  float64       `json:"frameRate,omitempty"`
+	ScanType   ScanType      `json:"scanType,omitempty"`
+}
+
+type (
+	// CreateJobRequest and similar data structures describe the requests and replies
+	// of the Job management endpoints.
+	CreateJobRequest struct {
+		Name       string `json:"name,omitempty"`
+		Source     string `json:"source"`
+		SourceInfo File   `json:"sourceInfo,omitempty"`
+
+		// Splice is a request to cut the source before processing. It falls somewhere
+		// between file metadata and a request by the user to operate on the source.
+		// Not every provider currently supports this feature.
+		Splice timecode.Splice `json:"splice,omitempty"`
+
+		Provider          string                      `json:"provider"`
+		ExecutionFeatures ExecutionFeatures           `json:"executionFeatures,omitempty"`
+		ExecutionEnv      ExecutionEnvironment        `json:"executionEnv,omitempty"`
+		StreamingParams   StreamingParams             `json:"streamingParams,omitempty"`
+		SidecarAssets     map[SidecarAssetKind]string `json:"sidecarAssets,omitempty"`
+
+		DestinationBasePath string      `json:"destinationBasePath,omitempty"`
+		Outputs             []JobOutput `json:"outputs"`
+	}
+	CreateJobResponse struct {
+		JobID JobID `json:"jobId"`
+	}
+	CancelJobRequest struct {
+		JobID JobID `json:"jobId"`
+	}
+	CancelJobResponse struct{ JobStatus }
+)
+
+// StreamingParams contains the configuration for media packaging
+type StreamingParams struct {
+	SegmentDuration  uint   `json:"segmentDuration"`
+	Protocol         string `json:"protocol"`
+	PlaylistFileName string `json:"playlistFileName,omitempty"`
+}
 
 // ExecutionEnvironment contains configurations for the environment used while transcoding
 type ExecutionEnvironment struct {
@@ -66,15 +108,20 @@ type ExecutionEnvironment struct {
 	OutputAlias      string                  `json:"outputAlias,omitempty"`
 }
 
-// ExecutionFeatures is a map whose key is a custom feature name and value is a json string
-// representing the corresponding custom feature definition
-type ExecutionFeatures map[string]interface{}
+// JobStatus is the representation of the status as the provider sees it.
+type JobStatus struct {
+	Progress      float64 `json:"progress"`
+	Status        Status  `json:"status,omitempty"`
+	StatusMessage string  `json:"statusMessage,omitempty"`
 
-// SidecarAssetKind is the type of sidecar asset being defined
-type SidecarAssetKind = string
+	ProviderJobID  string                 `json:"providerJobId,omitempty"`
+	ProviderName   string                 `json:"providerName,omitempty"`
+	ProviderStatus map[string]interface{} `json:"providerStatus,omitempty"`
 
-// SidecarAssetKindDolbyVisionMetadata defines the dolby vision dynamic metadata location
-const SidecarAssetKindDolbyVisionMetadata SidecarAssetKind = "dolbyVisionMetadata"
+	SourceInfo File `json:"sourceInfo,omitempty"`
+
+	Output OutputFiles `json:"output"`
+}
 
 // JobOutput defines config parameters for single output in a job
 type JobOutput struct {
@@ -82,73 +129,13 @@ type JobOutput struct {
 	Preset   PresetName `json:"preset"`
 }
 
-// CreateJobResponse contains the results of new job request
-type CreateJobResponse struct {
-	JobID JobID `json:"jobId"`
-}
-
-// StreamingParams contains the configuration for media packaging
-type StreamingParams struct {
-	SegmentDuration  uint   `json:"segmentDuration"`
-	Protocol         string `json:"protocol"`
-	PlaylistFileName string `json:"playlistFileName,omitempty"`
-}
-
-// CancelJobRequest contains the parameters needed to cancel a transcode job
-type CancelJobRequest struct {
-	JobID JobID `json:"jobId"`
-}
-
-// CancelJobResponse contains the results of cancel job request
-type CancelJobResponse struct {
-	JobStatus
-}
-
 // JobStatusResponse contains the results of describe job request
 type JobStatusResponse struct {
 	JobStatus
 }
 
-// JobStatus is the representation of the status as the provider sees it.
-type JobStatus struct {
-	ProviderJobID  string                 `json:"providerJobId,omitempty"`
-	Status         Status                 `json:"status,omitempty"`
-	ProviderName   string                 `json:"providerName,omitempty"`
-	StatusMessage  string                 `json:"statusMessage,omitempty"`
-	Progress       float64                `json:"progress"`
-	ProviderStatus map[string]interface{} `json:"providerStatus,omitempty"`
-	Output         OutputFiles            `json:"output"`
-	SourceInfo     SourceInfo             `json:"sourceInfo,omitempty"`
-}
-
-// SourceInfo contains information about media inputs
-type SourceInfo struct {
-	// Duration of the media
-	Duration time.Duration `json:"duration,omitempty"`
-
-	// Dimension of the media, in pixels
-	Height int64 `json:"height,omitempty"`
-	Width  int64 `json:"width,omitempty"`
-
-	// Codec used for video medias
-	VideoCodec string `json:"videoCodec,omitempty"`
-}
-
 // OutputFiles represents information about a job's outputs
 type OutputFiles struct {
-	Destination string       `json:"destination,omitempty"`
-	Files       []OutputFile `json:"files,omitempty"`
+	Destination string `json:"destination,omitempty"`
+	Files       []File `json:"files,omitempty"`
 }
-
-// OutputFile represents an output file in a given job.
-type OutputFile struct {
-	Path       string `json:"path"`
-	Container  string `json:"container"`
-	VideoCodec string `json:"videoCodec"`
-	Height     int64  `json:"height"`
-	Width      int64  `json:"width"`
-	FileSize   int64  `json:"fileSize"`
-}
-
-// Status is the status of a transcoding job.
-type Status string


### PR DESCRIPTION
This is somewhat of a reorganization of the `job_dto.go` file that de-duplicates data structures and groups relevant ones in related locations throughout the file.

- Location of the constants are moved to the top of the file (as per the godoc standard)

- Some redundant comments are removed. We can use grouping to silence the linter if this is a problem.

```
const (
        // ScanTypeUnknown and other ScanTypes support... etc
	ScanTypeUnknown     ScanType = "unknown"
	ScanTypeProgressive ScanType = "progressive"
	ScanTypeInterlaced  ScanType = "interlaced"
)
```

- Lots of types were redefined. We fix that by just creating a File type:
```
// File is a media file. It replaces the following objects
// SourceInfo: Duration, Height, Width, Codec
// CreateJobSourceInfo: Height, Width, FrameRate, File Size, ScanType
// SourceInfo: ...
type File struct {
	Path       string        `json:"path"`
	Size       int64         `json:"fileSize"`
	Container  string        `json:"container"`
	Duration   time.Duration `json:"duration,omitempty"`
	VideoCodec string        `json:"videoCodec,omitempty"`
	Width      int           `json:"width,omitempty"`
	Height     int           `json:"height,omitempty"`
	FrameRate  float64       `json:"frameRate,omitempty"`
	ScanType   ScanType      `json:"scanType,omitempty"`
}
```