### PR TITLE
bitmovin: splice support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v0.21.0
 	github.com/bitmovin/bitmovin-api-sdk-go v1.37.0-alpha.0
 	github.com/cbsinteractive/hybrik-sdk-go v0.0.0-20191031180025-00f04ed90532
-	github.com/cbsinteractive/pkg/timecode v0.0.0-20200409233703-f2037b1185c6
+	github.com/cbsinteractive/pkg/timecode v0.0.0-20200805005557-c8cd96fa0686
 	github.com/fsouza/ctxlogger v1.5.9
 	github.com/fsouza/gizmo-stackdriver-logging v1.3.2
 	github.com/getsentry/sentry-go v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/cbsinteractive/hybrik-sdk-go v0.0.0-20191031180025-00f04ed90532 h1:J3
 github.com/cbsinteractive/hybrik-sdk-go v0.0.0-20191031180025-00f04ed90532/go.mod h1:5JlyzszNqCntcqS9TkCb23lxY/1LWBMJ8agSSYTrAJU=
 github.com/cbsinteractive/pkg/timecode v0.0.0-20200409233703-f2037b1185c6 h1:zdcxUaMXo54QPrAmlV1dIhXSovjz0EfM0v/5FZ1cCi8=
 github.com/cbsinteractive/pkg/timecode v0.0.0-20200409233703-f2037b1185c6/go.mod h1:ReOY3qLLv1Aafa5tt2x78vbSZQu6YOyH3yq64Fd4uVA=
+github.com/cbsinteractive/pkg/timecode v0.0.0-20200805005557-c8cd96fa0686 h1:BBkzPbx8OdHNUYROX4qIa7euONzlE0r6eDL72MQ54m4=
+github.com/cbsinteractive/pkg/timecode v0.0.0-20200805005557-c8cd96fa0686/go.mod h1:ReOY3qLLv1Aafa5tt2x78vbSZQu6YOyH3yq64Fd4uVA=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/provider/bitmovin/bitmovin.go
+++ b/provider/bitmovin/bitmovin.go
@@ -348,13 +348,14 @@ func (p *bitmovinProvider) Transcode(ctx context.Context, job *db.Job) (*provide
 			sp, ep := r.Timecodes(0)
 			splice, err := p.api.Encoding.Encodings.InputStreams.Trimming.TimecodeTrack.Create(enc.Id, model.TimecodeTrackTrimmingInputStream{
 				Name:          "splice",
+				InputStreamId: inputID,
 				StartTimeCode: sp,
 				EndTimeCode:   ep,
 			})
 			if err != nil {
 				return err
 			}
-			splice = splice
+			splice = splice // TODO
 		}
 		return nil
 	}()

--- a/provider/bitmovin/bitmovin.go
+++ b/provider/bitmovin/bitmovin.go
@@ -3,7 +3,7 @@ package bitmovin
 import (
 	"context"
 	"fmt"
-	"log"
+
 	"net/url"
 	"path"
 	"sort"
@@ -284,8 +284,6 @@ func (p *bitmovinProvider) Transcode(ctx context.Context, job *db.Job) (*provide
 		return nil, errors.Wrap(err, "creating encoding")
 	}
 	subSeg.Close(nil)
-	log.Println("encoding")
-	log.Printf("inputID: %q", inputID)
 
 	subSeg = p.tracer.BeginSubsegment(ctx, "bitmovin-create-ingest")
 	err = func() error {
@@ -301,8 +299,6 @@ func (p *bitmovinProvider) Transcode(ctx context.Context, job *db.Job) (*provide
 	if err != nil {
 		return nil, fmt.Errorf("ingest: %v", err)
 	}
-	log.Println("ingest")
-	log.Printf("inputID: %q", inputID)
 
 	subSeg = p.tracer.BeginSubsegment(ctx, "bitmovin-create-concatenated-splice")
 	inputID, err = func(inputID string) (string, error) {
@@ -372,9 +368,6 @@ func (p *bitmovinProvider) Transcode(ctx context.Context, job *db.Job) (*provide
 	if err != nil {
 		return nil, fmt.Errorf("splice: %w", err)
 	}
-	log.Println("splice")
-	log.Printf("inputID: %q", inputID)
-
 	videoFilters := map[int]string{}
 	if processingVideo {
 		subSeg := p.tracer.BeginSubsegment(ctx, "bitmovin-create-deinterlace-filter")

--- a/provider/bitmovin/bitmovin.go
+++ b/provider/bitmovin/bitmovin.go
@@ -364,7 +364,7 @@ func (p *bitmovinProvider) Transcode(ctx context.Context, job *db.Job) (*provide
 		}
 		return c.Id, nil
 	}(inputID)
-	defer subSeg.Close(err)
+	subSeg.Close(err)
 	if err != nil {
 		return nil, fmt.Errorf("splice: %w", err)
 	}

--- a/service/transcode.go
+++ b/service/transcode.go
@@ -42,6 +42,7 @@ func (s *TranscodingService) newTranscodeJob(r *http.Request) swagger.GizmoJSONR
 		Name:                input.Payload.Name,
 		SourceMedia:         input.Payload.Source,
 		SourceInfo:          input.Payload.SourceInfo,
+		SourceSplice:        input.Payload.SourceSplice,
 		DestinationBasePath: input.Payload.DestinationBasePath,
 		ExecutionEnv:        input.Payload.ExecutionEnv,
 		SidecarAssets:       input.Payload.SidecarAssets,

--- a/service/transcode_params.go
+++ b/service/transcode_params.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/cbsinteractive/pkg/timecode"
 	"github.com/cbsinteractive/transcode-orchestrator/db"
 	"github.com/cbsinteractive/transcode-orchestrator/provider"
 )
@@ -17,6 +18,11 @@ type NewTranscodeJobInputPayload struct {
 
 	// SourceInfo is an optional param allowing users to add helpful information about the source content
 	SourceInfo db.SourceInfo `json:"sourceInfo,omitempty"`
+
+	// SourceSplice is a set of second ranges to excise from the input and catenate
+	// together before processing the source. For example, [[0,1],[8,9]], will cut out
+	// a two-second clip, from the first and last second of a 10s video.
+	SourceSplice timecode.Splice `json:"splice,omitempty"`
 
 	// list of outputs in this job
 	Outputs []struct {

--- a/vendor/github.com/cbsinteractive/pkg/timecode/splice.go
+++ b/vendor/github.com/cbsinteractive/pkg/timecode/splice.go
@@ -75,3 +75,8 @@ func (s *Splice) UnmarshalText(p []byte) error {
 	// does videorobot do?
 	return json.Unmarshal(p, (*[]Range)(s))
 }
+
+// UnmarshalJSON calls UnmarshalText on the splice
+func (s *Splice) UnmarshalJSON(p []byte) error {
+	return s.UnmarshalText(p)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -126,7 +126,7 @@ github.com/bitmovin/bitmovin-api-sdk-go/serialization
 # github.com/cbsinteractive/hybrik-sdk-go v0.0.0-20191031180025-00f04ed90532
 ## explicit
 github.com/cbsinteractive/hybrik-sdk-go
-# github.com/cbsinteractive/pkg/timecode v0.0.0-20200409233703-f2037b1185c6
+# github.com/cbsinteractive/pkg/timecode v0.0.0-20200805005557-c8cd96fa0686
 ## explicit
 github.com/cbsinteractive/pkg/timecode
 # github.com/facebookgo/stack v0.0.0-20160209184415-751773369052


### PR DESCRIPTION
This PR adds splice support for the bitmovin provider. A splice is a set of time ranges expressed in seconds that cuts audio/video tracks from those time ranges and concatenates them together before sending them as input to the encoder instead of the entire input file.