### PR TITLE
Job labels

### DIFF
--- a/db/types.go
+++ b/db/types.go
@@ -65,6 +65,9 @@ type Job struct {
 
 	// AudioDownmix holds source and output channels for configuring downmixing
 	AudioDownmix *AudioDownmix `json:"audioDownmix,omitempty"`
+
+	// Optional list of string labels
+	Labels []string `redis-hash:"labels" json:"labels"`
 }
 
 type SidecarAssetKind = string

--- a/db/types.go
+++ b/db/types.go
@@ -67,7 +67,7 @@ type Job struct {
 	AudioDownmix *AudioDownmix `json:"audioDownmix,omitempty"`
 
 	// Optional list of string labels
-	Labels []string `redis-hash:"labels" json:"labels"`
+	Labels []string `redis-hash:"labels,omitempty" json:"labels,omitempty"`
 }
 
 type SidecarAssetKind = string

--- a/provider/flock/flock.go
+++ b/provider/flock/flock.go
@@ -43,6 +43,7 @@ type JobRequest struct {
 type JobSpec struct {
 	Source  string      `json:"source"`
 	Outputs []JobOutput `json:"outputs"`
+	Labels  []string    `json:"labels"`
 }
 
 type JobOutput struct {
@@ -155,6 +156,11 @@ func (p *flock) flockJobRequestFrom(ctx context.Context, job *db.Job) (*JobReque
 
 	var jobReq JobRequest
 	jobReq.Job.Source = job.SourceMedia
+
+	jobReq.Job.Labels = make([]string, 0)
+	for _,label := range job.Labels {
+		jobReq.Job.Labels = append(jobReq.Job.Labels, label)
+	}
 
 	jobOuts := make([]JobOutput, 0, len(job.Outputs))
 	for i, output := range job.Outputs {
@@ -282,6 +288,7 @@ func (p *flock) jobStatusFrom(job *db.Job, jobResp *JobResponse) *provider.JobSt
 		Output: provider.JobOutput{
 			Destination: joinBaseAndParts(job.DestinationBasePath, job.ID),
 		},
+		Labels: job.Labels,
 	}
 
 	outputsStatus := make([]map[string]interface{}, 0, len(jobResp.Outputs))

--- a/provider/flock/flock.go
+++ b/provider/flock/flock.go
@@ -157,7 +157,6 @@ func (p *flock) flockJobRequestFrom(ctx context.Context, job *db.Job) (*JobReque
 	var jobReq JobRequest
 	jobReq.Job.Source = job.SourceMedia
 
-	jobReq.Job.Labels = make([]string, 0)
 	for _,label := range job.Labels {
 		jobReq.Job.Labels = append(jobReq.Job.Labels, label)
 	}

--- a/provider/flock/flock.go
+++ b/provider/flock/flock.go
@@ -43,7 +43,7 @@ type JobRequest struct {
 type JobSpec struct {
 	Source  string      `json:"source"`
 	Outputs []JobOutput `json:"outputs"`
-	Labels  []string    `json:"labels"`
+	Labels  []string    `json:"labels,omitempty"`
 }
 
 type JobOutput struct {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -80,6 +80,7 @@ type JobStatus struct {
 	ProviderStatus map[string]interface{} `json:"providerStatus,omitempty"`
 	Output         JobOutput              `json:"output"`
 	SourceInfo     SourceInfo             `json:"sourceInfo,omitempty"`
+	Labels         []string               `json:"labels,omitempty"`
 }
 
 // JobOutput represents information about a job output.

--- a/service/fake_provider_test.go
+++ b/service/fake_provider_test.go
@@ -75,6 +75,7 @@ func (p *fakeProvider) JobStatus(_ context.Context, job *db.Job) (*provider.JobS
 			Output: provider.JobOutput{
 				Destination: "s3://mybucket/some/dir/job-123",
 			},
+			Labels: job.Labels,
 		}, nil
 	}
 	return nil, provider.JobNotFoundError{ID: id}

--- a/service/transcode.go
+++ b/service/transcode.go
@@ -48,6 +48,7 @@ func (s *TranscodingService) newTranscodeJob(r *http.Request) swagger.GizmoJSONR
 		StreamingParams:     input.Payload.StreamingParams,
 		ExecutionFeatures:   input.Payload.ExecutionFeatures,
 		ExecutionCfgReport:  fmt.Sprint(input.Payload.ExecutionFeatures),
+		Labels:              input.Payload.Labels,
 	}
 	outputs := make([]db.TranscodeOutput, len(input.Payload.Outputs))
 	for i, output := range input.Payload.Outputs {

--- a/service/transcode_params.go
+++ b/service/transcode_params.go
@@ -45,7 +45,7 @@ type NewTranscodeJobInputPayload struct {
 	// provider Adaptive Streaming parameters
 	StreamingParams db.StreamingParams `json:"streamingParams,omitempty"`
 
-	// job labels
+	// Labels for jobs for grouping/searching later on
 	Labels []string `json:"labels,omitempty"`
 }
 

--- a/service/transcode_params.go
+++ b/service/transcode_params.go
@@ -44,6 +44,9 @@ type NewTranscodeJobInputPayload struct {
 
 	// provider Adaptive Streaming parameters
 	StreamingParams db.StreamingParams `json:"streamingParams,omitempty"`
+
+	// job labels
+	Labels []string `json:"labels"`
 }
 
 // swagger:parameters newJob

--- a/service/transcode_params.go
+++ b/service/transcode_params.go
@@ -46,7 +46,7 @@ type NewTranscodeJobInputPayload struct {
 	StreamingParams db.StreamingParams `json:"streamingParams,omitempty"`
 
 	// job labels
-	Labels []string `json:"labels"`
+	Labels []string `json:"labels,omitempty"`
 }
 
 // swagger:parameters newJob

--- a/service/transcode_test.go
+++ b/service/transcode_test.go
@@ -30,7 +30,7 @@ func TestTranscode(t *testing.T) {
 		wantSegmentDuration  uint
 	}{
 		{
-			"New job",
+			"NewJob",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -47,7 +47,7 @@ func TestTranscode(t *testing.T) {
 			3,
 		},
 		{
-			"New job - default playlist file name & segment duration",
+			"NewJobDefaultPlaylistFileNameAndSegmentDuration",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -64,7 +64,7 @@ func TestTranscode(t *testing.T) {
 			5,
 		},
 		{
-			"New job - default playlist file name, segment duration & regular file name",
+			"NewJobDefaultPlaylistFileNameSegmentDurationAndRegularFileName",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -81,7 +81,7 @@ func TestTranscode(t *testing.T) {
 			5,
 		},
 		{
-			"New job - no playlist file name",
+			"NewJobNoPlaylistFileName",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -98,7 +98,7 @@ func TestTranscode(t *testing.T) {
 			0,
 		},
 		{
-			"New job - default output file name",
+			"NewJobDefaultOutputFileName",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -114,7 +114,7 @@ func TestTranscode(t *testing.T) {
 			0,
 		},
 		{
-			"New job with preset not found in provider",
+			"NewJobWithPresetNotFoundInProvider",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -130,7 +130,7 @@ func TestTranscode(t *testing.T) {
 			0,
 		},
 		{
-			"New job with preset not found in the API",
+			"NewJobWithPresetNotFoundInTheAPI",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -162,7 +162,7 @@ func TestTranscode(t *testing.T) {
 			0,
 		},
 		{
-			"New job with invalid provider",
+			"NewJobWithInvalidProvider",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -178,7 +178,7 @@ func TestTranscode(t *testing.T) {
 			0,
 		},
 		{
-			"New job missing outputs",
+			"NewJobMissingOutputs",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -193,7 +193,7 @@ func TestTranscode(t *testing.T) {
 			0,
 		},
 		{
-			"New job labels empty list",
+			"NewJobLabelsEmptyList",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",
@@ -210,7 +210,7 @@ func TestTranscode(t *testing.T) {
 			0,
 		},
 		{
-			"New job labels null",
+			"NewJobLabelsNull",
 			`{
   "source": "http://another.non.existent/video.mp4",
   "destination": "s3://some.bucket.s3.amazonaws.com/some_path",

--- a/service/transcode_test.go
+++ b/service/transcode_test.go
@@ -529,8 +529,8 @@ func TestGetTranscodeJobLabels(t *testing.T) {
 					"destination": "s3://mybucket/some/dir/job-123",
 				},
 				"sourceInfo": map[string]interface{}{
-					"width":      float64(4096),
-					"height":     float64(2160),
+					"width":      4096.0,
+					"height":     2160.0,
 					"duration":   183e9,
 					"videoCodec": "VP9",
 				},
@@ -558,8 +558,8 @@ func TestGetTranscodeJobLabels(t *testing.T) {
 					"destination": "s3://mybucket/some/dir/job-123",
 				},
 				"sourceInfo": map[string]interface{}{
-					"width":      float64(4096),
-					"height":     float64(2160),
+					"width":      4096.0,
+					"height":     2160.0,
 					"duration":   183e9,
 					"videoCodec": "VP9",
 				},
@@ -588,8 +588,8 @@ func TestGetTranscodeJobLabels(t *testing.T) {
 					"destination": "s3://mybucket/some/dir/job-123",
 				},
 				"sourceInfo": map[string]interface{}{
-					"width":      float64(4096),
-					"height":     float64(2160),
+					"width":      4096.0,
+					"height":     2160.0,
 					"duration":   183e9,
 					"videoCodec": "VP9",
 				},


### PR DESCRIPTION
Adding labels to jobs: a list of string labels can optionally be specified in the request. 
Transcode orchestrator stores them in its own storage and also passes them on to providers (right now only done for Flock), so that cost information can be requested later from the providers using those labels.