### PR TITLE
all: remove 'tt := tt' from all tests

### DIFF
--- a/provider/bitmovin/internal/container/cmaf_test.go
+++ b/provider/bitmovin/internal/container/cmaf_test.go
@@ -241,7 +241,7 @@ func TestCMAFAssembler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			err := NewCMAFAssembler(tt.api).Assemble(tt.cfg)
 			if shouldReturn := test.AssertWantErr(err, tt.wantErr, "Assemble()", t); shouldReturn {

--- a/provider/bitmovin/internal/container/hls_test.go
+++ b/provider/bitmovin/internal/container/hls_test.go
@@ -241,7 +241,7 @@ func TestNewHLSAssembler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			err := NewHLSAssembler(tt.api).Assemble(tt.cfg)
 			if shouldReturn := test.AssertWantErr(err, tt.wantErr, "Assemble()", t); shouldReturn {

--- a/provider/bitmovin/internal/storage/inputs_test.go
+++ b/provider/bitmovin/internal/storage/inputs_test.go
@@ -148,7 +148,7 @@ func TestNewInput(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			id, err := NewInput(tt.srcMedia, tt.api, &tt.cfg)
 			if shouldReturn := test.AssertWantErr(err, tt.wantErr, "NewInput()", t); shouldReturn {

--- a/provider/bitmovin/internal/storage/outputs_test.go
+++ b/provider/bitmovin/internal/storage/outputs_test.go
@@ -118,7 +118,7 @@ func TestNewOutput(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			id, err := NewOutput(tt.destLoc, tt.api, &tt.cfg)
 			if shouldReturn := test.AssertWantErr(err, tt.wantErr, "NewOutput()", t); shouldReturn {

--- a/provider/hybrik/hybrik_test.go
+++ b/provider/hybrik/hybrik_test.go
@@ -156,7 +156,7 @@ func TestHybrikProvider_transcodeElementFromPreset(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			p, err := tt.provider.transcodeElementFromPreset(tt.preset, tt.transcodeCfg.uid, jobCfg{
 				destination:       tt.transcodeCfg.destination,
@@ -264,7 +264,7 @@ func TestHybrikProvider_transcodeElementFromPreset_fields(t *testing.T) {
 				}
 
 				for _, tt := range tests {
-					tt := tt
+
 					t.Run(tt.name, func(t *testing.T) {
 						if g, e := tt.got, tt.want; !reflect.DeepEqual(g, e) {
 							t.Fatalf("%s: got %q, expected %q", tt.name, g, e)
@@ -308,7 +308,7 @@ func TestHybrikProvider_transcodeElementFromPreset_fields(t *testing.T) {
 				}
 
 				for _, tt := range tests {
-					tt := tt
+
 					t.Run(tt.name, func(t *testing.T) {
 						if g, e := tt.got, tt.want; !reflect.DeepEqual(g, e) {
 							t.Fatalf("%s: got %q, expected %q", tt.name, g, e)
@@ -342,7 +342,7 @@ func TestHybrikProvider_transcodeElementFromPreset_fields(t *testing.T) {
 				}
 
 				for _, tt := range tests {
-					tt := tt
+
 					t.Run(tt.name, func(t *testing.T) {
 						if g, e := tt.got, tt.want; !reflect.DeepEqual(g, e) {
 							t.Fatalf("%s: got %v, expected %v", tt.name, g, e)
@@ -405,7 +405,7 @@ func TestHybrikProvider_transcodeElementFromPreset_fields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			p := &hybrikProvider{
 				config: &config.Hybrik{
@@ -852,7 +852,7 @@ func TestHybrikProvider_presetsToTranscodeJob(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			fakeDB, err := fakeDBWithPreset(tt.preset)
 			if err != nil {
@@ -1147,7 +1147,7 @@ func TestHybrikProvider_presetsToTranscodeJob_fields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			fakeDB, err := fakeDBWithPreset(defaultPreset)
 			if err != nil {

--- a/provider/hybrik/job_status_mapping_test.go
+++ b/provider/hybrik/job_status_mapping_test.go
@@ -110,7 +110,7 @@ func Test_filesFrom(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			file, err := ioutil.ReadFile(tt.file)
 			if err != nil {

--- a/provider/hybrik/storage_test.go
+++ b/provider/hybrik/storage_test.go
@@ -42,7 +42,7 @@ func Test_storageProviderFrom(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			prov, err := storageProviderFrom(tt.path)
 			if shouldReturn := assertWantErr(err, tt.wantErr, "storageProviderFrom()", t); shouldReturn {

--- a/provider/mediaconvert/factory_test.go
+++ b/provider/mediaconvert/factory_test.go
@@ -82,7 +82,7 @@ func Test_mediaconvertFactory(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envVars {
 				resetFunc, err := setenvReset(k, v)

--- a/provider/mediaconvert/hdr_test.go
+++ b/provider/mediaconvert/hdr_test.go
@@ -57,7 +57,7 @@ func Test_parseMasterDisplay(t *testing.T) {
 	}
 
 	for _, tt := range test {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			display, err := parseMasterDisplay(tt.encodedStr)
 			if (err != nil) != tt.wantErr {

--- a/provider/mediaconvert/mediaconvert_test.go
+++ b/provider/mediaconvert/mediaconvert_test.go
@@ -331,7 +331,7 @@ func Test_mcProvider_CreatePreset_fields(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			client := &testMediaConvertClient{t: t}
 
@@ -1443,7 +1443,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			repo, err := fakeDBWithPresets(tt.preset)
 			if err != nil {
@@ -1620,7 +1620,7 @@ func Test_mcProvider_JobStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
 			client := &testMediaConvertClient{
 				t:                   t,


### PR DESCRIPTION
This assignment is not necessary so let's remove it from our tests
to stop the pattern from proliferating.