### PR TITLE
mxf: mediaconvert: support mp4 -> mxf workflow

### DIFF
--- a/client/transcoding/job_dto.go
+++ b/client/transcoding/job_dto.go
@@ -73,8 +73,6 @@ type File struct {
 	Height     int      `json:"height,omitempty"`
 	FrameRate  float64  `json:"frameRate,omitempty"`
 	ScanType   ScanType `json:"scanType,omitempty"`
-
-	AudioChannels int `json:"audioChannels,omitempty"`
 }
 
 type (

--- a/client/transcoding/job_dto.go
+++ b/client/transcoding/job_dto.go
@@ -63,15 +63,18 @@ type AudioDownmix struct {
 // CreateJobSourceInfo: Height, Width, FrameRate, File Size, ScanType
 // SourceInfo:
 type File struct {
-	Path       string        `json:"path"`
-	Size       int64         `json:"fileSize"`
-	Container  string        `json:"container"`
-	Duration   time.Duration `json:"duration,omitempty"`
-	VideoCodec string        `json:"videoCodec,omitempty"`
-	Width      int           `json:"width,omitempty"`
-	Height     int           `json:"height,omitempty"`
-	FrameRate  float64       `json:"frameRate,omitempty"`
-	ScanType   ScanType      `json:"scanType,omitempty"`
+	Path      string        `json:"path"`
+	Size      int64         `json:"fileSize"`
+	Container string        `json:"container"`
+	Duration  time.Duration `json:"duration,omitempty"`
+
+	VideoCodec string   `json:"videoCodec,omitempty"`
+	Width      int      `json:"width,omitempty"`
+	Height     int      `json:"height,omitempty"`
+	FrameRate  float64  `json:"frameRate,omitempty"`
+	ScanType   ScanType `json:"scanType,omitempty"`
+
+	AudioChannels int `json:"audioChannels,omitempty"`
 }
 
 type (

--- a/client/transcoding/preset_dto.go
+++ b/client/transcoding/preset_dto.go
@@ -110,4 +110,6 @@ type AudioPreset struct {
 	Codec         string `json:"codec,omitempty"`
 	Bitrate       string `json:"bitrate,omitempty"`
 	Normalization bool   `json:"normalization,omitempty"`
+
+	DiscreteTracks bool `json:"discreteTracks,omitempty"`
 }

--- a/db/redis/localpreset_test.go
+++ b/db/redis/localpreset_test.go
@@ -37,9 +37,10 @@ func TestCreateLocalPreset(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedItems := map[string]string{
-		"preset_name":                "test",
-		"preset_twopass":             "false",
-		"preset_audio_normalization": "false",
+		"preset_name":                 "test",
+		"preset_twopass":              "false",
+		"preset_audio_normalization":  "false",
+		"preset_audio_discreteTracks": "false",
 	}
 	if !reflect.DeepEqual(items, expectedItems) {
 		t.Errorf("Wrong preset hash returned from Redis. Want %#v. Got %#v", expectedItems, items)
@@ -104,9 +105,10 @@ func TestUpdateLocalPreset(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedItems := map[string]string{
-		"preset_name":                "test-different",
-		"preset_twopass":             "false",
-		"preset_audio_normalization": "false",
+		"preset_name":                 "test-different",
+		"preset_twopass":              "false",
+		"preset_audio_normalization":  "false",
+		"preset_audio_discreteTracks": "false",
 	}
 	if !reflect.DeepEqual(items, expectedItems) {
 		t.Errorf("Wrong presetmap hash returned from Redis. Want %#v. Got %#v", expectedItems, items)

--- a/db/types.go
+++ b/db/types.go
@@ -321,6 +321,8 @@ type AudioPreset struct {
 	Codec         string `json:"codec,omitempty" redis-hash:"codec,omitempty"`
 	Bitrate       string `json:"bitrate,omitempty" redis-hash:"bitrate,omitempty"`
 	Normalization bool   `json:"normalization,omitempty" redis-hash:"normalization,omitempty"`
+
+	DiscreteTracks bool `json:"discreteTracks,omitempty" redis-hash:"discreteTracks,omitempty"`
 }
 
 // PresetMap represents the preset that is persisted in the repository of the

--- a/provider/mediaconvert/mediaconvert.go
+++ b/provider/mediaconvert/mediaconvert.go
@@ -221,7 +221,7 @@ func (p *mcProvider) outputGroupsFrom(ctx context.Context, job *db.Job) ([]media
 					SegmentControl:         mediaconvert.HlsSegmentControlSegmentedFiles,
 				},
 			}
-		case mediaconvert.ContainerTypeMp4, mediaconvert.ContainerTypeMov, mediaconvert.ContainerTypeWebm:
+		case mediaconvert.ContainerTypeMp4, mediaconvert.ContainerTypeMov, mediaconvert.ContainerTypeWebm, mediaconvert.ContainerTypeMxf:
 			mcOutputGroup.OutputGroupSettings = &mediaconvert.OutputGroupSettings{
 				Type: mediaconvert.OutputGroupTypeFileGroupSettings,
 				FileGroupSettings: &mediaconvert.FileGroupSettings{

--- a/provider/mediaconvert/mpeg2.go
+++ b/provider/mediaconvert/mpeg2.go
@@ -45,7 +45,7 @@ type mpeg2 struct {
 	*/
 }
 
-func (m mpeg2) apply(p db.Preset) mpeg2 {
+func (m mpeg2) apply(p db.Preset) (mpeg2) {
 	return m //TODO
 }
 
@@ -64,7 +64,7 @@ func (m mpeg2) generate() (*mediaconvert.VideoCodecSettings, error) {
 var mpeg2default = mpeg2{
 	CodecProfile:    "PROFILE_422",
 	Bitrate:         50000000,
-	GopSize:         12,
+	GopSize:         60,
 	InterlaceMode:   "TOP_FIELD",
 	RateControlMode: "CBR",
 

--- a/provider/mediaconvert/mpeg2.go
+++ b/provider/mediaconvert/mpeg2.go
@@ -10,32 +10,6 @@ import (
 	"github.com/cbsinteractive/transcode-orchestrator/db"
 )
 
-type mpeg2 struct {
-	InterlaceMode                       string
-	Syntax                              string
-	GopClosedCadence                    int64
-	GopSize                             float64
-	SlowPal                             string
-	SpatialAdaptiveQuantization         string
-	TemporalAdaptiveQuantization        string
-	Bitrate                             int64
-	IntraDcPrecision                    string
-	FramerateControl                    string
-	RateControlMode                     string
-	CodecProfile                        string
-	Telecine                            string
-	MinIInterval                        int64
-	AdaptiveQuantization                string
-	CodecLevel                          string
-	SceneChangeDetect                   string
-	QualityTuningLevel                  string
-	FramerateConversionAlgorithm        string
-	GopSizeUnits                        string
-	ParControl                          string
-	NumberBFramesBetweenReferenceFrames int64
-	DynamicSubGop                       string
-}
-
 var ErrProfileUnsupported = errors.New("unsupported profile")
 
 var mpeg2profiles = map[string]string{
@@ -88,31 +62,57 @@ func (m mpeg2) generate(p db.Preset) (*mediaconvert.VideoCodecSettings, error) {
 	return s, s.Validate()
 }
 
+type mpeg2 struct {
+	InterlaceMode                       string
+	Syntax                              string
+	GopClosedCadence                    int64
+	GopSize                             float64
+	SlowPal                             string
+	SpatialAdaptiveQuantization         string
+	TemporalAdaptiveQuantization        string
+	Bitrate                             int64
+	IntraDcPrecision                    string
+	FramerateControl                    string
+	RateControlMode                     string
+	CodecProfile                        string
+	Telecine                            string
+	MinIInterval                        int64
+	AdaptiveQuantization                string
+	CodecLevel                          string
+	SceneChangeDetect                   string
+	QualityTuningLevel                  string
+	FramerateConversionAlgorithm        string
+	GopSizeUnits                        string
+	ParControl                          string
+	NumberBFramesBetweenReferenceFrames int64
+	DynamicSubGop                       string
+}
+
 var mpeg2default = mpeg2{
+	Syntax:          "DEFAULT",
 	CodecProfile:    "PROFILE_422",
+	CodecLevel:      "HIGH",
 	Bitrate:         50000000,
-	GopSize:         60,
 	InterlaceMode:   "TOP_FIELD",
 	RateControlMode: "CBR",
 
-	Syntax:                              "DEFAULT",
+	GopSize:                             60,
 	GopClosedCadence:                    1,
+	GopSizeUnits:                        "FRAMES",
 	SlowPal:                             "DISABLED",
+	DynamicSubGop:                       "STATIC",
 	SpatialAdaptiveQuantization:         "ENABLED",
 	TemporalAdaptiveQuantization:        "ENABLED",
+	SceneChangeDetect:                   "ENABLED",
 	IntraDcPrecision:                    "AUTO",
 	FramerateControl:                    "INITIALIZE_FROM_SOURCE",
 	Telecine:                            "NONE",
 	MinIInterval:                        0,
 	AdaptiveQuantization:                "HIGH",
-	CodecLevel:                          "HIGH",
-	SceneChangeDetect:                   "ENABLED",
 	QualityTuningLevel:                  "SINGLE_PASS",
 	FramerateConversionAlgorithm:        "DUPLICATE_DROP",
-	GopSizeUnits:                        "FRAMES",
 	ParControl:                          "INITIALIZE_FROM_SOURCE",
 	NumberBFramesBetweenReferenceFrames: 2,
-	DynamicSubGop:                       "STATIC",
 }
 
 var mpeg2XDCAM = mpeg2default

--- a/provider/mediaconvert/mpeg2.go
+++ b/provider/mediaconvert/mpeg2.go
@@ -23,17 +23,17 @@ func atoi(a string) int64 {
 }
 
 func (m mpeg2) validate(p db.Preset) error {
-	if c := p.Video.Codec; c != "" {
-		if _, ok := mpeg2profiles[c]; !ok {
-			return fmt.Errorf("%w: %q", ErrProfileUnsupported, c)
+	if profile := p.Video.Profile; profile != "" {
+		if _, ok := mpeg2profiles[profile]; !ok {
+			return fmt.Errorf("%w: %q", ErrProfileUnsupported, profile)
 		}
 	}
 	return nil
 }
 
 func (m mpeg2) apply(p db.Preset) mpeg2 {
-	if p.Video.Codec != "" {
-		m.CodecProfile = mpeg2profiles[p.Video.Codec]
+	if p.Video.Profile != "" {
+		m.CodecProfile = mpeg2profiles[p.Video.Profile]
 	}
 	if p.Video.Bitrate != "" {
 		m.Bitrate = aws.Int64(atoi(p.Video.Bitrate))

--- a/provider/mediaconvert/mpeg2.go
+++ b/provider/mediaconvert/mpeg2.go
@@ -1,0 +1,91 @@
+package mediaconvert
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go-v2/service/mediaconvert"
+	"github.com/cbsinteractive/transcode-orchestrator/db"
+)
+
+type mpeg2 struct {
+	InterlaceMode                       string
+	Syntax                              string
+	GopClosedCadence                    int64
+	GopSize                             float64
+	SlowPal                             string
+	SpatialAdaptiveQuantization         string
+	TemporalAdaptiveQuantization        string
+	Bitrate                             int64
+	IntraDcPrecision                    string
+	FramerateControl                    string
+	RateControlMode                     string
+	CodecProfile                        string
+	Telecine                            string
+	MinIInterval                        int64
+	AdaptiveQuantization                string
+	CodecLevel                          string
+	SceneChangeDetect                   string
+	QualityTuningLevel                  string
+	FramerateConversionAlgorithm        string
+	GopSizeUnits                        string
+	ParControl                          string
+	NumberBFramesBetweenReferenceFrames int64
+	DynamicSubGop                       string
+
+	/*
+		FramerateDenominator int64
+		FramerateNumerator int64
+
+		HrdBufferInitialFillPercentage
+		HrdBufferSize int64
+		MaxBitrate int64
+		ParDenominator int64
+		ParNumerator int64
+		Softness int64
+	*/
+}
+
+func (m mpeg2) apply(p db.Preset) mpeg2 {
+	return m //TODO
+}
+
+func (m mpeg2) generate() (*mediaconvert.VideoCodecSettings, error) {
+	s := &mediaconvert.VideoCodecSettings{
+		Codec:         mediaconvert.VideoCodecMpeg2,
+		Mpeg2Settings: &mediaconvert.Mpeg2Settings{},
+	}
+	data, _ := json.Marshal(m)
+	if err := json.Unmarshal(data, s.Mpeg2Settings); err != nil{
+		return s, err
+	}
+	return s, s.Validate()
+}
+
+var mpeg2default = mpeg2{
+	CodecProfile:    "PROFILE_422",
+	Bitrate:         50000000,
+	GopSize:         12,
+	InterlaceMode:   "TOP_FIELD",
+	RateControlMode: "CBR",
+
+	Syntax:                              "DEFAULT",
+	GopClosedCadence:                    1,
+	SlowPal:                             "DISABLED",
+	SpatialAdaptiveQuantization:         "ENABLED",
+	TemporalAdaptiveQuantization:        "ENABLED",
+	IntraDcPrecision:                    "AUTO",
+	FramerateControl:                    "INITIALIZE_FROM_SOURCE",
+	Telecine:                            "NONE",
+	MinIInterval:                        0,
+	AdaptiveQuantization:                "HIGH",
+	CodecLevel:                          "HIGH",
+	SceneChangeDetect:                   "ENABLED",
+	QualityTuningLevel:                  "SINGLE_PASS",
+	FramerateConversionAlgorithm:        "DUPLICATE_DROP",
+	GopSizeUnits:                        "FRAMES",
+	ParControl:                          "INITIALIZE_FROM_SOURCE",
+	NumberBFramesBetweenReferenceFrames: 2,
+	DynamicSubGop:                       "STATIC",
+}
+
+var mpeg2XDCAM = mpeg2default

--- a/provider/mediaconvert/mpeg2_test.go
+++ b/provider/mediaconvert/mpeg2_test.go
@@ -21,7 +21,7 @@ func TestGenerateMPEG2(t *testing.T) {
 		t.Fatalf("bad config: %+v", s)
 	}
 
-	p.Video.Codec = "hd4444444"
+	p.Video.Profile = "hd4444444"
 	s, err = mpeg2XDCAM.generate(p)
 	if !errors.Is(err, ErrProfileUnsupported) {
 		t.Fatalf("have %v want %v", err, ErrProfileUnsupported)

--- a/provider/mediaconvert/mpeg2_test.go
+++ b/provider/mediaconvert/mpeg2_test.go
@@ -2,48 +2,29 @@ package mediaconvert
 
 import (
 	"encoding/json"
-	"reflect"
+	"errors"
 	"testing"
+
+	"github.com/cbsinteractive/transcode-orchestrator/db"
 )
 
 func TestGenerateMPEG2(t *testing.T) {
-	s, err := mpeg2XDCAM.generate()
-	t.Log(s, s.Validate(), err)
-
-	if false{
-
-	want := makemap(`
-{
-                  "InterlaceMode": "TOP_FIELD",
-                  "Syntax": "DEFAULT",
-                  "GopClosedCadence": 1,
-                  "GopSize": 12,
-                  "SlowPal": "DISABLED",
-                  "SpatialAdaptiveQuantization": "ENABLED",
-                  "TemporalAdaptiveQuantization": "ENABLED",
-                  "Bitrate": 50000000,
-                  "IntraDcPrecision": "AUTO",
-                  "FramerateControl": "INITIALIZE_FROM_SOURCE",
-                  "RateControlMode": "CBR",
-                  "CodecProfile": "PROFILE_422",
-                  "Telecine": "NONE",
-                  "MinIInterval": 0,
-                  "AdaptiveQuantization": "HIGH",
-                  "CodecLevel": "HIGH",
-                  "SceneChangeDetect": "ENABLED",
-                  "QualityTuningLevel": "SINGLE_PASS",
-                  "FramerateConversionAlgorithm": "DUPLICATE_DROP",
-                  "GopSizeUnits": "FRAMES",
-                  "ParControl": "INITIALIZE_FROM_SOURCE",
-                  "NumberBFramesBetweenReferenceFrames": 2,
-                  "DynamicSubGop": "STATIC"
-}
-`)
-	have := makemap(s.Mpeg2Settings)
-
-	if !reflect.DeepEqual(have, want) {
-		t.Fatalf("not equal:\n		have: %+v\n		want: %+v\n", have, want)
+	p := db.Preset{}
+	p.Video.Codec = "hd422"
+	p.Video.GopSize = "6000"
+	p.Video.Bitrate = "6000"
+	s, err := mpeg2XDCAM.generate(p)
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
+	if *s.Mpeg2Settings.GopSize != 6000 || *s.Mpeg2Settings.Bitrate != 6000 {
+		t.Fatalf("bad config: %+v", s)
+	}
+
+	p.Video.Codec = "hd4444444"
+	s, err = mpeg2XDCAM.generate(p)
+	if !errors.Is(err, ErrProfileUnsupported) {
+		t.Fatalf("have %v want %v", err, ErrProfileUnsupported)
 	}
 }
 

--- a/provider/mediaconvert/mpeg2_test.go
+++ b/provider/mediaconvert/mpeg2_test.go
@@ -1,0 +1,62 @@
+package mediaconvert
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestGenerateMPEG2(t *testing.T) {
+	s, err := mpeg2XDCAM.generate()
+	t.Log(s, s.Validate(), err)
+
+	if false{
+
+	want := makemap(`
+{
+                  "InterlaceMode": "TOP_FIELD",
+                  "Syntax": "DEFAULT",
+                  "GopClosedCadence": 1,
+                  "GopSize": 12,
+                  "SlowPal": "DISABLED",
+                  "SpatialAdaptiveQuantization": "ENABLED",
+                  "TemporalAdaptiveQuantization": "ENABLED",
+                  "Bitrate": 50000000,
+                  "IntraDcPrecision": "AUTO",
+                  "FramerateControl": "INITIALIZE_FROM_SOURCE",
+                  "RateControlMode": "CBR",
+                  "CodecProfile": "PROFILE_422",
+                  "Telecine": "NONE",
+                  "MinIInterval": 0,
+                  "AdaptiveQuantization": "HIGH",
+                  "CodecLevel": "HIGH",
+                  "SceneChangeDetect": "ENABLED",
+                  "QualityTuningLevel": "SINGLE_PASS",
+                  "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+                  "GopSizeUnits": "FRAMES",
+                  "ParControl": "INITIALIZE_FROM_SOURCE",
+                  "NumberBFramesBetweenReferenceFrames": 2,
+                  "DynamicSubGop": "STATIC"
+}
+`)
+	have := makemap(s.Mpeg2Settings)
+
+	if !reflect.DeepEqual(have, want) {
+		t.Fatalf("not equal:\n		have: %+v\n		want: %+v\n", have, want)
+	}
+	}
+}
+
+func makemap(v interface{}) (m map[string]interface{}) {
+	data := []byte{}
+	switch v := v.(type) {
+	case string:
+		data = []byte(v)
+	case []byte:
+		data = v
+	case interface{}:
+		data, _ = json.Marshal(v)
+	}
+	json.Unmarshal(data, &m)
+	return m
+}

--- a/provider/mediaconvert/preset_mapping.go
+++ b/provider/mediaconvert/preset_mapping.go
@@ -202,11 +202,6 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 			Mode:      mediaconvert.DeinterlacerModeDeinterlace,
 		}
 	default:
-		videoPreset.VideoPreprocessors.Deinterlacer = &mediaconvert.Deinterlacer{
-			Algorithm: mediaconvert.DeinterlaceAlgorithmInterpolate,
-			Control:   mediaconvert.DeinterlacerControlNormal,
-			Mode:      mediaconvert.DeinterlacerModeAdaptive,
-		}
 	}
 
 	return &videoPreset, nil

--- a/provider/mediaconvert/preset_mapping.go
+++ b/provider/mediaconvert/preset_mapping.go
@@ -154,6 +154,9 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 	switch codec {
 	case "xdcam":
 		s, err = mpeg2XDCAM.generate(preset)
+		defer func() {
+			videoPreset.VideoPreprocessors.Deinterlacer = nil
+		}()
 	case "h264":
 		s, err = h264CodecSettingsFrom(preset)
 	case "h265":
@@ -176,6 +179,9 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 	}
 	videoPreset.VideoPreprocessors = videoPreprocessors
 
+	if preset.Video.InterlaceMode != "progressive" {
+		return &videoPreset, nil
+	}
 	switch sourceInfo.ScanType {
 	case db.ScanTypeProgressive:
 	case db.ScanTypeInterlaced:

--- a/provider/mediaconvert/preset_mapping_test.go
+++ b/provider/mediaconvert/preset_mapping_test.go
@@ -1,6 +1,12 @@
 package mediaconvert
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/mediaconvert"
+	"github.com/aws/aws-sdk-go/aws"
+)
 
 func Test_vbrLevel(t *testing.T) {
 	tests := []struct {
@@ -45,5 +51,64 @@ func Test_vbrLevel(t *testing.T) {
 				t.Errorf("vbrLevel() = %v, want %v", got, tt.wantLevel)
 			}
 		})
+	}
+}
+
+func TestAudioSplit(t *testing.T) {
+	input := mediaconvert.AudioDescription{
+		CodecSettings: &mediaconvert.AudioCodecSettings{
+			Codec: mediaconvert.AudioCodecWav,
+			WavSettings: &mediaconvert.WavSettings{
+				BitDepth:   aws.Int64(24),
+				Channels:   aws.Int64(2),
+				SampleRate: aws.Int64(48000),
+				Format:     "RIFF",
+			},
+		},
+	}
+
+	want := []mediaconvert.AudioDescription{{
+		RemixSettings: &mediaconvert.RemixSettings{
+			ChannelMapping: &mediaconvert.ChannelMapping{
+				OutputChannels: []mediaconvert.OutputChannelMapping{{
+					InputChannels: []int64{0, -60},
+				},
+				}},
+			ChannelsIn:  aws.Int64(2),
+			ChannelsOut: aws.Int64(1),
+		},
+		CodecSettings: &mediaconvert.AudioCodecSettings{
+			Codec: mediaconvert.AudioCodecWav,
+			WavSettings: &mediaconvert.WavSettings{
+				BitDepth:   aws.Int64(24),
+				Channels:   aws.Int64(1),
+				SampleRate: aws.Int64(48000),
+				Format:     "RIFF",
+			},
+		},
+	}, {
+		RemixSettings: &mediaconvert.RemixSettings{
+			ChannelMapping: &mediaconvert.ChannelMapping{
+				OutputChannels: []mediaconvert.OutputChannelMapping{{
+					InputChannels: []int64{-60, 0},
+				},
+				}},
+			ChannelsIn:  aws.Int64(2),
+			ChannelsOut: aws.Int64(1),
+		},
+		CodecSettings: &mediaconvert.AudioCodecSettings{
+			Codec: mediaconvert.AudioCodecWav,
+			WavSettings: &mediaconvert.WavSettings{
+				BitDepth:   aws.Int64(24),
+				Channels:   aws.Int64(1),
+				SampleRate: aws.Int64(48000),
+				Format:     "RIFF",
+			},
+		},
+	}}
+
+	have := audioSplit(input)
+	if !reflect.DeepEqual(have, want) {
+		t.Fatalf("bad split:\nhave:\t\t%v\nwant:\t\t%v", have, want)
 	}
 }


### PR DESCRIPTION
smartapi.json
```
{
	"sources": [
		{
			"url": "https://p191.p3.n0.cdn.getcloudapp.com/items/xQuAqrZr/Manchester%20City%20vs.%20FC%20Porto%20-%20Game%20Highlights%20(1).mp4?source=client"
		}
	],
	"outputs": [
		{
			"type": "archive",
			"config": {
				"format": "xdcam-hd422",
				"container": "mxf"
			}
		}
	]
}
```

presets.json
```
;  curl http://localhost:34157/presets --data '{ "providers": [  "mediaconvert" ], "preset": { "name": "whatever", "container": "mxf", "rateControl": "CBR", "video": { "height": "1080", "width": "1920", "codec": "xdcam", "profile": "hd422", "bitrate": "5000000", "gopSize": "60", "gopMode": "fixed", "interlaceMode": "interlaced" }, "audio": { "codec": "pcm", "discreteTracks": true } } }'
```

job.json
```
curl http://localhost:34157/jobs --data '{"provider": "mediaconvert","source": "s3://vtg-as-test-bucket/mxf/test/in.mp4","destinationBasePath": "s3://vtg-as-test-bucket/mxf/test","outputs": [{"preset": "whatever","fileName": "out.mxf"}],"labels": ["bill:some-bu"]}'
```
