### PR TITLE
MediaConvert job tags

### DIFF
--- a/provider/mediaconvert/mediaconvert.go
+++ b/provider/mediaconvert/mediaconvert.go
@@ -128,7 +128,8 @@ func (p *mcProvider) Transcode(ctx context.Context, job *db.Job) (*provider.JobS
 				Source: mediaconvert.TimecodeSourceZerobased,
 			},
 		},
-		Tags: p.tagsFrom(job.Labels),
+		Tags:              p.tagsFrom(job.Labels),
+		BillingTagsSource: "JOB",
 	}).Send(ctx)
 	if err != nil {
 		return nil, err
@@ -438,7 +439,9 @@ func (p *mcProvider) tagsFrom(labels []string) map[string]string {
 	tags := make(map[string]string)
 
 	for _, label := range labels {
-		tags[label] = "true"
+		if strings.HasPrefix(label, "bill:") {
+			tags["bu"] = label
+		}
 	}
 
 	return tags

--- a/provider/mediaconvert/mediaconvert.go
+++ b/provider/mediaconvert/mediaconvert.go
@@ -440,7 +440,11 @@ func (p *mcProvider) tagsFrom(labels []string) map[string]string {
 
 	for _, label := range labels {
 		if strings.HasPrefix(label, "bill:") {
+			// in case of billing tag we need to use a Cost Allocation Tag
+			// for cost to be reported correctly by Cost Explorer API
 			tags["bu"] = label
+		} else {
+			tags[label] = "true"
 		}
 	}
 

--- a/provider/mediaconvert/mediaconvert_test.go
+++ b/provider/mediaconvert/mediaconvert_test.go
@@ -453,8 +453,9 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			wantJobReq: mediaconvert.CreateJobInput{
 				Role:  aws.String("some-role"),
 				Queue: aws.String("some:default:queue:arn"),
+				BillingTagsSource: "JOB",
 				Tags: map[string]string{
-					"bill:some-bu":     "true",
+					"bu":               "bill:some-bu",
 					"some-more-labels": "true",
 				},
 				Settings: &mediaconvert.JobSettings{
@@ -561,6 +562,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			wantJobReq: mediaconvert.CreateJobInput{
 				Role:  aws.String(""),
 				Queue: aws.String(""),
+				BillingTagsSource: "JOB",
 				Tags:  map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
@@ -666,6 +668,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			wantJobReq: mediaconvert.CreateJobInput{
 				Role:  aws.String(""),
 				Queue: aws.String(""),
+				BillingTagsSource: "JOB",
 				Tags:  map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
@@ -762,6 +765,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			wantJobReq: mediaconvert.CreateJobInput{
 				Role:  aws.String(""),
 				Queue: aws.String(""),
+				BillingTagsSource: "JOB",
 				Tags:  map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
@@ -858,6 +862,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			wantJobReq: mediaconvert.CreateJobInput{
 				Role:  aws.String(""),
 				Queue: aws.String(""),
+				BillingTagsSource: "JOB",
 				Tags:  map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
@@ -942,6 +947,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			wantJobReq: mediaconvert.CreateJobInput{
 				Role:  aws.String(""),
 				Queue: aws.String(""),
+				BillingTagsSource: "JOB",
 				Tags:  map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
@@ -1039,6 +1045,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			wantJobReq: mediaconvert.CreateJobInput{
 				Role:  aws.String(""),
 				Queue: aws.String(""),
+				BillingTagsSource: "JOB",
 				Tags:  map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
@@ -1141,6 +1148,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 				Role:            aws.String(""),
 				Queue:           aws.String("some:preferred:queue:arn"),
 				HopDestinations: []mediaconvert.HopDestination{{WaitMinutes: aws.Int64(defaultQueueHopTimeoutMins)}},
+				BillingTagsSource: "JOB",
 				Tags:            map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
@@ -1262,6 +1270,7 @@ func Test_mcProvider_Transcode(t *testing.T) {
 				Role:            aws.String(""),
 				Queue:           aws.String("some:preferred:queue:arn"),
 				HopDestinations: []mediaconvert.HopDestination{{WaitMinutes: aws.Int64(defaultQueueHopTimeoutMins)}},
+				BillingTagsSource: "JOB",
 				Tags:            map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{

--- a/provider/mediaconvert/mediaconvert_test.go
+++ b/provider/mediaconvert/mediaconvert_test.go
@@ -451,8 +451,8 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      defaultPreset,
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:  aws.String("some-role"),
-				Queue: aws.String("some:default:queue:arn"),
+				Role:              aws.String("some-role"),
+				Queue:             aws.String("some:default:queue:arn"),
 				BillingTagsSource: "JOB",
 				Tags: map[string]string{
 					"bu":               "bill:some-bu",
@@ -560,10 +560,10 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      defaultPreset,
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:  aws.String(""),
-				Queue: aws.String(""),
+				Role:              aws.String(""),
+				Queue:             aws.String(""),
 				BillingTagsSource: "JOB",
-				Tags:  map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{
@@ -666,10 +666,10 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      defaultPreset,
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:  aws.String(""),
-				Queue: aws.String(""),
+				Role:              aws.String(""),
+				Queue:             aws.String(""),
 				BillingTagsSource: "JOB",
-				Tags:  map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{
@@ -763,10 +763,10 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      h265Preset,
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:  aws.String(""),
-				Queue: aws.String(""),
+				Role:              aws.String(""),
+				Queue:             aws.String(""),
 				BillingTagsSource: "JOB",
-				Tags:  map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{
@@ -860,10 +860,10 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      av1Preset,
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:  aws.String(""),
-				Queue: aws.String(""),
+				Role:              aws.String(""),
+				Queue:             aws.String(""),
 				BillingTagsSource: "JOB",
-				Tags:  map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{
@@ -945,10 +945,10 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      vp8Preset("vorbis"),
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:  aws.String(""),
-				Queue: aws.String(""),
+				Role:              aws.String(""),
+				Queue:             aws.String(""),
 				BillingTagsSource: "JOB",
-				Tags:  map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{
@@ -1043,10 +1043,10 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      vp8Preset("opus"),
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:  aws.String(""),
-				Queue: aws.String(""),
+				Role:              aws.String(""),
+				Queue:             aws.String(""),
 				BillingTagsSource: "JOB",
-				Tags:  map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{
@@ -1145,11 +1145,11 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      defaultPreset,
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:            aws.String(""),
-				Queue:           aws.String("some:preferred:queue:arn"),
-				HopDestinations: []mediaconvert.HopDestination{{WaitMinutes: aws.Int64(defaultQueueHopTimeoutMins)}},
+				Role:              aws.String(""),
+				Queue:             aws.String("some:preferred:queue:arn"),
+				HopDestinations:   []mediaconvert.HopDestination{{WaitMinutes: aws.Int64(defaultQueueHopTimeoutMins)}},
 				BillingTagsSource: "JOB",
-				Tags:            map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{
@@ -1267,11 +1267,11 @@ func Test_mcProvider_Transcode(t *testing.T) {
 			preset:      tcBurninPreset,
 			destination: "s3://some/destination",
 			wantJobReq: mediaconvert.CreateJobInput{
-				Role:            aws.String(""),
-				Queue:           aws.String("some:preferred:queue:arn"),
-				HopDestinations: []mediaconvert.HopDestination{{WaitMinutes: aws.Int64(defaultQueueHopTimeoutMins)}},
+				Role:              aws.String(""),
+				Queue:             aws.String("some:preferred:queue:arn"),
+				HopDestinations:   []mediaconvert.HopDestination{{WaitMinutes: aws.Int64(defaultQueueHopTimeoutMins)}},
 				BillingTagsSource: "JOB",
-				Tags:            map[string]string{},
+				Tags:              map[string]string{},
 				Settings: &mediaconvert.JobSettings{
 					Inputs: []mediaconvert.Input{
 						{


### PR DESCRIPTION
small tweak to how we tag MediaConvert jobs.
- special logic for billing label, to use a fixed tag name, and have BU information in tag value
- make sure to set BillingTagsSource (otherwise jobs are not associated with Cost Allocation Tags)
