### PR TITLE
mediaconvert: cropping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitmovin/bitmovin-api-sdk-go v1.37.0-alpha.0
 	github.com/cbsinteractive/hybrik-sdk-go v0.0.0-20191031180025-00f04ed90532
 	github.com/cbsinteractive/pkg/timecode v0.0.0-20200805005557-c8cd96fa0686
-	github.com/cbsinteractive/pkg/video v0.0.0-20200829195108-cc8210d024ab
+	github.com/cbsinteractive/pkg/video v0.0.2
 	github.com/fsouza/ctxlogger v1.5.9
 	github.com/fsouza/gizmo-stackdriver-logging v1.3.2
 	github.com/getsentry/sentry-go v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/cbsinteractive/pkg/video v0.0.0-20200829154626-5096cad96783 h1:xjOawh
 github.com/cbsinteractive/pkg/video v0.0.0-20200829154626-5096cad96783/go.mod h1:r5qPR/TvTmjEetSAp7Pr5xmAGt3L06pPYElzWxBCBZg=
 github.com/cbsinteractive/pkg/video v0.0.0-20200829195108-cc8210d024ab h1:JjKy1bPpjeeVC4c4wteRpXO79Dn6rcAH7x3Zr0H7YRk=
 github.com/cbsinteractive/pkg/video v0.0.0-20200829195108-cc8210d024ab/go.mod h1:r5qPR/TvTmjEetSAp7Pr5xmAGt3L06pPYElzWxBCBZg=
+github.com/cbsinteractive/pkg/video v0.0.2 h1:WkhrxH5rET6HjpaI04Jn/bFpFs8DltG6fGmCja8r0cI=
+github.com/cbsinteractive/pkg/video v0.0.2/go.mod h1:r5qPR/TvTmjEetSAp7Pr5xmAGt3L06pPYElzWxBCBZg=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/provider/mediaconvert/preset_mapping.go
+++ b/provider/mediaconvert/preset_mapping.go
@@ -131,8 +131,13 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 		RespondToAfd:      mediaconvert.RespondToAfdNone,
 	}
 
+	var (
+		width, height int64
+		err           error
+		s             *mediaconvert.VideoCodecSettings
+	)
 	if preset.Video.Width != "" {
-		width, err := strconv.ParseInt(preset.Video.Width, 10, 64)
+		width, err = strconv.ParseInt(preset.Video.Width, 10, 64)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing video width %q to int64", preset.Video.Width)
 		}
@@ -140,15 +145,12 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 	}
 
 	if preset.Video.Height != "" {
-		height, err := strconv.ParseInt(preset.Video.Height, 10, 64)
+		height, err = strconv.ParseInt(preset.Video.Height, 10, 64)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing video height %q to int64", preset.Video.Height)
 		}
 		videoPreset.Height = aws.Int64(height)
 	}
-
-	var s *mediaconvert.VideoCodecSettings
-	var err error
 
 	codec := strings.ToLower(preset.Video.Codec)
 	switch codec {
@@ -178,6 +180,16 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 		return nil, errors.Wrap(err, "building videoPreprocessors")
 	}
 	videoPreset.VideoPreprocessors = videoPreprocessors
+
+	// cropping
+	if crop := preset.Video.Crop; !crop.Empty() && height > 0 && width > 0 {
+		videoPreset.Crop = &mediaconvert.Rectangle{
+			Height: aws.Int64(height - int64(crop.Top+crop.Bottom)),
+			Width:  aws.Int64(width - int64(crop.Left+crop.Right)),
+			X:      aws.Int64(int64(crop.Left)),
+			Y:      aws.Int64(int64(crop.Top)),
+		}
+	}
 
 	videoPreset = setter{dst: preset, src: sourceInfo}.ScanType(videoPreset)
 

--- a/provider/mediaconvert/preset_mapping.go
+++ b/provider/mediaconvert/preset_mapping.go
@@ -197,7 +197,9 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 		}
 	}
 
-	videoPreset = setter{dst: preset, src: sourceInfo}.ScanType(videoPreset)
+	cfgSetter := setter{dst: preset, src: sourceInfo}
+	videoPreset = cfgSetter.ScanType(videoPreset)
+	videoPreset = cfgSetter.Crop(videoPreset)
 
 	return videoPreset, nil
 }
@@ -250,6 +252,34 @@ func (s setter) ScanType(v *mediaconvert.VideoDescription) *mediaconvert.VideoDe
 		default:
 			v.VideoPreprocessors.Deinterlacer = &deinterlacerAdaptive
 		}
+	}
+	return v
+}
+
+func (s setter) Crop(v *mediaconvert.VideoDescription) *mediaconvert.VideoDescription {
+	if v == nil {
+		v = &mediaconvert.VideoDescription{}
+	}
+
+	var (
+		crop = s.dst.Video.Crop
+		h, w = int(s.src.Height), int(s.src.Width)
+	)
+	if crop.Empty() || h <= 0 || w <= 0 {
+		return v
+	}
+
+	roundEven := func(i, mod int) *int64 {
+		if i%2 != 0 {
+			i += mod
+		}
+		return aws.Int64(int64(i))
+	}
+	v.Crop = &mediaconvert.Rectangle{
+		Height: roundEven(h-crop.Top-crop.Bottom, -1),
+		Width:  roundEven(w-crop.Left-crop.Right, -1),
+		X:      roundEven(crop.Left, 1),
+		Y:      roundEven(crop.Top, 1),
 	}
 	return v
 }

--- a/provider/mediaconvert/preset_mapping.go
+++ b/provider/mediaconvert/preset_mapping.go
@@ -131,13 +131,8 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 		RespondToAfd:      mediaconvert.RespondToAfdNone,
 	}
 
-	var (
-		width, height int64
-		err           error
-		s             *mediaconvert.VideoCodecSettings
-	)
 	if preset.Video.Width != "" {
-		width, err = strconv.ParseInt(preset.Video.Width, 10, 64)
+		width, err := strconv.ParseInt(preset.Video.Width, 10, 64)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing video width %q to int64", preset.Video.Width)
 		}
@@ -145,12 +140,15 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 	}
 
 	if preset.Video.Height != "" {
-		height, err = strconv.ParseInt(preset.Video.Height, 10, 64)
+		height, err := strconv.ParseInt(preset.Video.Height, 10, 64)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing video height %q to int64", preset.Video.Height)
 		}
 		videoPreset.Height = aws.Int64(height)
 	}
+
+	var s *mediaconvert.VideoCodecSettings
+	var err error
 
 	codec := strings.ToLower(preset.Video.Codec)
 	switch codec {

--- a/provider/mediaconvert/preset_mapping.go
+++ b/provider/mediaconvert/preset_mapping.go
@@ -181,22 +181,6 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 	}
 	videoPreset.VideoPreprocessors = videoPreprocessors
 
-	// cropping
-	if crop := preset.Video.Crop; !crop.Empty() && height > 0 && width > 0 {
-		roundEven := func(i, mod int) *int64 {
-			if i%2 != 0 {
-				i += mod
-			}
-			return aws.Int64(int64(i))
-		}
-		videoPreset.Crop = &mediaconvert.Rectangle{
-			Height: roundEven(int(height)-crop.Top+crop.Bottom, -1),
-			Width:  roundEven(int(width)-crop.Left+crop.Right, -1),
-			X:      roundEven(crop.Left, 1),
-			Y:      roundEven(crop.Top, 1),
-		}
-	}
-
 	cfgSetter := setter{dst: preset, src: sourceInfo}
 	videoPreset = cfgSetter.ScanType(videoPreset)
 	videoPreset = cfgSetter.Crop(videoPreset)

--- a/provider/mediaconvert/preset_mapping.go
+++ b/provider/mediaconvert/preset_mapping.go
@@ -183,11 +183,17 @@ func videoPresetFrom(preset db.Preset, sourceInfo db.File) (*mediaconvert.VideoD
 
 	// cropping
 	if crop := preset.Video.Crop; !crop.Empty() && height > 0 && width > 0 {
+		roundEven := func(i, mod int) *int64 {
+			if i%2 != 0 {
+				i += mod
+			}
+			return aws.Int64(int64(i))
+		}
 		videoPreset.Crop = &mediaconvert.Rectangle{
-			Height: aws.Int64(height - int64(crop.Top+crop.Bottom)),
-			Width:  aws.Int64(width - int64(crop.Left+crop.Right)),
-			X:      aws.Int64(int64(crop.Left)),
-			Y:      aws.Int64(int64(crop.Top)),
+			Height: roundEven(int(height)-crop.Top+crop.Bottom, -1),
+			Width:  roundEven(int(width)-crop.Left+crop.Right, -1),
+			X:      roundEven(crop.Left, 1),
+			Y:      roundEven(crop.Top, 1),
 		}
 	}
 

--- a/provider/mediaconvert/preset_mapping_test.go
+++ b/provider/mediaconvert/preset_mapping_test.go
@@ -82,18 +82,20 @@ func TestSetterScanType(t *testing.T) {
 	}
 }
 
-func TestVideoMapping(t *testing.T) {
+func TestVideo(t *testing.T) {
 	i64 := func(i int64) *int64 { return &i }
 
 	for _, tt := range []struct {
 		name   string
+		src    db.File
 		video  db.VideoPreset
 		assert func(t *testing.T, desc *mediaconvert.VideoDescription)
 	}{
 		{
 			name: "Crop",
+			src:  db.File{Height: 150, Width: 300},
 			video: db.VideoPreset{
-				Bitrate: "12000", GopSize: "2", Width: "300", Height: "150", Codec: "h264",
+				Bitrate: "12000", GopSize: "2", Width: "30", Height: "15", Codec: "h264",
 				Crop: video.Crop{
 					Top:    10,
 					Bottom: 20,
@@ -115,8 +117,9 @@ func TestVideoMapping(t *testing.T) {
 		},
 		{
 			name: "CropOddToEven",
+			src:  db.File{Height: 150, Width: 300},
 			video: db.VideoPreset{
-				Bitrate: "12000", GopSize: "2", Width: "300", Height: "150", Codec: "h264",
+				Bitrate: "12000", GopSize: "2", Width: "30", Height: "15", Codec: "h264",
 				Crop: video.Crop{
 					Top:    11,
 					Bottom: 25,
@@ -138,7 +141,7 @@ func TestVideoMapping(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			have, err := videoPresetFrom(db.Preset{Video: tt.video}, db.File{})
+			have, err := videoPresetFrom(db.Preset{Video: tt.video}, tt.src)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/provider/mediaconvert/preset_mapping_test.go
+++ b/provider/mediaconvert/preset_mapping_test.go
@@ -84,8 +84,8 @@ func TestSetterScanType(t *testing.T) {
 
 func TestCrop(t *testing.T) {
 	type (
-		dims struct{ height, width uint }
-		rect struct{ height, width, x, y int64 }
+		dims struct{ width, height uint }
+		rect struct{ width, height, x, y int64 }
 	)
 	for _, tt := range []struct {
 		name string
@@ -95,15 +95,15 @@ func TestCrop(t *testing.T) {
 	}{
 		{
 			"Crop",
-			dims{height: 150, width: 300},
-			video.Crop{Left: 50, Top: 10, Right: 40, Bottom: 20},
-			rect{height: 120, width: 210, x: 50, y: 10},
+			dims{width: 300, height: 150},
+			video.Crop{Top: 10, Right: 40, Bottom: 20, Left: 50},
+			rect{width: 210, height: 120, x: 50, y: 10},
 		},
 		{
 			"CropOdd2Even",
-			dims{height: 150, width: 300},
-			video.Crop{Left: 55, Top: 11, Right: 49, Bottom: 25},
-			rect{height: 114, width: 196, x: 56, y: 12},
+			dims{width: 300, height: 150},
+			video.Crop{Top: 11, Right: 49, Bottom: 25, Left: 55},
+			rect{width: 196, height: 114, x: 56, y: 12},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/provider/mediaconvert/preset_mapping_test.go
+++ b/provider/mediaconvert/preset_mapping_test.go
@@ -113,6 +113,29 @@ func TestVideoMapping(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "CropOddToEven",
+			video: db.VideoPreset{
+				Bitrate: "12000", GopSize: "2", Width: "300", Height: "150", Codec: "h264",
+				Crop: video.Crop{
+					Top:    11,
+					Bottom: 25,
+					Right:  49,
+					Left:   55,
+				},
+			},
+			assert: func(t *testing.T, got *mediaconvert.VideoDescription) {
+				want := &mediaconvert.Rectangle{
+					Height: i64(114),
+					Width:  i64(196),
+					X:      i64(56),
+					Y:      i64(12),
+				}
+				if !reflect.DeepEqual(got.Crop, want) {
+					t.Errorf("bad crop rect:\nhave: %+v\nwant: %+v", got.Crop, want)
+				}
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			have, err := videoPresetFrom(db.Preset{Video: tt.video}, db.File{})

--- a/provider/mediaconvert/preset_mapping_test.go
+++ b/provider/mediaconvert/preset_mapping_test.go
@@ -107,18 +107,13 @@ func TestCrop(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			have, err := videoPresetFrom(
-				db.Preset{
-					Video: db.VideoPreset{Bitrate: "12000", GopSize: "2", Width: "30", Height: "15", Codec: "h264", Crop: tt.crop},
-				},
-				db.File{Width: tt.src.width, Height: tt.src.height},
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
+			have := setter{
+				dst: db.Preset{Video: db.VideoPreset{Crop: tt.crop}},
+				src: db.File{Height: tt.src.height, Width: tt.src.width},
+			}.Crop(nil).Crop
 			want := &mediaconvert.Rectangle{Height: &tt.want.height, Width: &tt.want.width, X: &tt.want.x, Y: &tt.want.y}
-			if !reflect.DeepEqual(have.Crop, want) {
-				t.Errorf("bad crop rect:\nhave: %+v\nwant: %+v", have.Crop, tt.want)
+			if !reflect.DeepEqual(have, want) {
+				t.Errorf("bad crop rect:\nhave: %+v\nwant: %+v", have, tt.want)
 			}
 		})
 	}

--- a/vendor/github.com/cbsinteractive/pkg/video/crop.go
+++ b/vendor/github.com/cbsinteractive/pkg/video/crop.go
@@ -1,11 +1,34 @@
 package video
 
+import "image"
+
 // Crop holds offsets for top, bottom, left and right cropping, values are in pixels
 type Crop struct {
-	Top    int `json:"top,omitempty"`
-	Bottom int `json:"bottom,omitempty"`
-	Left   int `json:"left,omitempty"`
-	Right  int `json:"right,omitempty"`
+	Left   int `json:"left,omitempty" redis-hash:"left,omitempty"`
+	Top    int `json:"top,omitempty" redis-hash:"top,omitempty"`
+	Right  int `json:"right,omitempty" redis-hash:"right,omitempty"`
+	Bottom int `json:"bottom,omitempty" redis-hash:"bottom,omitempty"`
+}
+
+// Rect returns a Go rectangle, given the original source dimensions
+func (c Crop) Rect(src image.Rectangle) image.Rectangle {
+	return image.Rect(
+		src.Min.X+c.Left,
+		src.Min.Y+c.Top,
+		src.Max.X-c.Right,
+		src.Max.Y-c.Bottom,
+	).Intersect(src).Canon()
+}
+
+// From sets c to the result of the cropping operation, it is the
+// inverse of c.Rect
+func (c *Crop) From(src, crop image.Rectangle) {
+	src = src.Canon()
+	crop = src.Intersect(crop).Canon()
+	c.Left = crop.Min.X - src.Min.X
+	c.Top = crop.Min.Y - src.Min.Y
+	c.Right = src.Max.X - crop.Max.X
+	c.Bottom = src.Max.Y - crop.Max.Y
 }
 
 func (c Crop) Empty() bool {

--- a/vendor/github.com/cbsinteractive/pkg/video/dims.go
+++ b/vendor/github.com/cbsinteractive/pkg/video/dims.go
@@ -1,0 +1,6 @@
+package video
+
+type AspectRatio struct {
+	Numerator   int `json:"numerator"`
+	Denominator int `json:"denominator"`
+}

--- a/vendor/github.com/cbsinteractive/pkg/video/scale.go
+++ b/vendor/github.com/cbsinteractive/pkg/video/scale.go
@@ -1,0 +1,96 @@
+package video
+
+import "image"
+
+// Scale takes the src and crop rectangles
+// and outputs a center-weighted crop rectangle
+// with a bounds equal to src's aspect ratio.
+//
+// See https://github.com/as/croptest for a visual
+// representation
+func Scale(src, crop image.Rectangle) image.Rectangle {
+	return scale(src, crop)
+}
+
+// Aspect returns r's aspect ratio as a vector
+//
+// For the rectangle (0,0)-(1920,1080), Aspect returns
+// the point (16, 9).
+func Aspect(r image.Rectangle) (ar image.Point) {
+	return aspect(r)
+}
+
+func scale(s, c image.Rectangle) image.Rectangle {
+	c = c.Intersect(s) // fix bounds on bad crops
+
+	// obtain the center of the crop and save it
+	// then translate the crop to (0,0)
+	cc := center(c)
+	c = c.Sub(c.Min)
+
+	// compute the source's aspect ratio
+	// in integral units and compute the
+	// number of units cropped off, rounding
+	// up to the nearest whole
+	ar := Aspect(s)
+	d := delta(ar, s, c)
+
+	// pick the largest cut on either the x or y axis
+	u := max(d.X, d.Y)
+
+	// set the new crop rectangle to the number of pixels
+	// those units represent in the source
+	c.Max.X = s.Max.X - u*ar.X
+	c.Max.Y = s.Max.Y - u*ar.Y
+
+	// translate the new crop to the center of where the
+	// old one used to be
+	return c.Add(cc.Sub(center(c)))
+}
+
+func aspect(r image.Rectangle) (ar image.Point) {
+	s := r.Size()
+	g := gcd(s.X, s.Y)
+	if g != 0 {
+		return s.Div(g)
+	}
+	return s
+}
+
+func center(r image.Rectangle) image.Point {
+	return r.Min.Add(r.Size().Div(2))
+}
+
+// delta returns the difference between src and r
+// in units of the aspect ratio ar, rounded up to the
+// nearest whole unit
+func delta(ar image.Point, src, r image.Rectangle) (units image.Point) {
+	if ar.X == 0 || ar.Y == 0{
+		return image.ZP
+	}
+	return image.Pt(
+		((src.Dx() - r.Dx() + ar.X - 1) / ar.X),
+		((src.Dy() - r.Dy() + ar.Y - 1) / ar.Y),
+	)
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}
+
+func gcd(a, b int) int {
+	for a != 0 {
+		a, b = b%a, a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -127,7 +127,7 @@ github.com/cbsinteractive/hybrik-sdk-go
 # github.com/cbsinteractive/pkg/timecode v0.0.0-20200805005557-c8cd96fa0686
 ## explicit
 github.com/cbsinteractive/pkg/timecode
-# github.com/cbsinteractive/pkg/video v0.0.0-20200829195108-cc8210d024ab
+# github.com/cbsinteractive/pkg/video v0.0.2
 ## explicit
 github.com/cbsinteractive/pkg/video
 # github.com/facebookgo/stack v0.0.0-20160209184415-751773369052


### PR DESCRIPTION
EMC requires `x`, `y`, `height`, and `width` to be even